### PR TITLE
Allow conversion from IColorVector

### DIFF
--- a/Colourful.Tests/XYZAndxyYConversionTest.cs
+++ b/Colourful.Tests/XYZAndxyYConversionTest.cs
@@ -74,5 +74,24 @@ namespace Colourful.Tests
             Assert.That(output.y, Is.EqualTo(y).Using(DoubleComparer));
             Assert.That(output.Luminance, Is.EqualTo(Y).Using(DoubleComparer));
         }
+
+        [Test]
+        [TestCaseSource("TestData")]
+        [TestCase(0, 0, 0, 0.538842, 0.000000, 0.000000)]
+        public void Convert_xyY_as_vector_to_XYZ(double xyzX, double xyzY, double xyzZ, double x, double y, double Y)
+        {
+            // arrange
+            IColorVector input = new xyYColor(x, y, Y);
+
+            var converter = new ColourfulConverter();
+
+            // act
+            XYZColor output = converter.ToXYZ(input);
+
+            // assert
+            Assert.That(output.X, Is.EqualTo(xyzX).Using(DoubleComparer));
+            Assert.That(output.Y, Is.EqualTo(xyzY).Using(DoubleComparer));
+            Assert.That(output.Z, Is.EqualTo(xyzZ).Using(DoubleComparer));
+        }
     }
 }

--- a/Colourful.Tests/XYZAndxyYConversionTest.cs
+++ b/Colourful.Tests/XYZAndxyYConversionTest.cs
@@ -93,5 +93,23 @@ namespace Colourful.Tests
             Assert.That(output.Y, Is.EqualTo(xyzY).Using(DoubleComparer));
             Assert.That(output.Z, Is.EqualTo(xyzZ).Using(DoubleComparer));
         }
+
+        [Test]
+        [TestCase(0.538842, 0.000000, 0.000000)]
+        public void Convert_XYZ_as_vector_to_XYZ(double x, double y, double z)
+        {
+            // arrange
+            IColorVector input = new XYZColor(x, y, z);
+
+            var converter = new ColourfulConverter();
+
+            // act
+            XYZColor output = converter.ToXYZ(input);
+
+            // assert
+            Assert.That(output.X, Is.EqualTo(x).Using(DoubleComparer));
+            Assert.That(output.Y, Is.EqualTo(y).Using(DoubleComparer));
+            Assert.That(output.Z, Is.EqualTo(z).Using(DoubleComparer));
+        }
     }
 }

--- a/Colourful/Colourful.csproj
+++ b/Colourful/Colourful.csproj
@@ -77,6 +77,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/Colourful/Colourful.csproj
+++ b/Colourful/Colourful.csproj
@@ -77,7 +77,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.CSharp" Condition="'$(Configuration)|$(Platform)' != 'Release %28.NET 3.5%29|AnyCPU'" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/Colourful/Conversion/ColourfulConverter.ToHunterLab.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToHunterLab.cs
@@ -105,5 +105,14 @@ namespace Colourful.Conversion
             HunterLabColor result = ToHunterLab(xyzColor);
             return result;
         }
+
+        public HunterLabColor ToHunterLab<T>(T color) where T : IColorVector
+        {
+            if (color == null) throw new ArgumentNullException("color");
+
+            dynamic source = color;
+
+            return ToHunterLab(source);
+        }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToHunterLab.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToHunterLab.cs
@@ -110,9 +110,18 @@ namespace Colourful.Conversion
         {
             if (color == null) throw new ArgumentNullException("color");
 
-            dynamic source = color;
+            HunterLabColor converted = color as HunterLabColor;
 
-            return ToHunterLab(source);
+            if (converted != null)
+            {
+                return converted;
+            }
+            else
+            {
+                dynamic source = color;
+
+                return ToHunterLab(source);
+            }
         }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToHunterLab.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToHunterLab.cs
@@ -105,7 +105,9 @@ namespace Colourful.Conversion
             HunterLabColor result = ToHunterLab(xyzColor);
             return result;
         }
-
+        
+#if (NET35)
+#else
         public HunterLabColor ToHunterLab<T>(T color) where T : IColorVector
         {
             if (color == null) throw new ArgumentNullException("color");
@@ -123,5 +125,6 @@ namespace Colourful.Conversion
                 return ToHunterLab(source);
             }
         }
+#endif
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLChab.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLChab.cs
@@ -103,7 +103,9 @@ namespace Colourful.Conversion
             LChabColor result = ToLChab(xyzColor);
             return result;
         }
-
+        
+#if (NET35)
+#else
         public LChabColor ToLChab<T>(T color) where T : IColorVector
         {
             if (color == null) throw new ArgumentNullException("color");
@@ -121,5 +123,6 @@ namespace Colourful.Conversion
                 return ToLChab(source);
             }
         }
+#endif
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLChab.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLChab.cs
@@ -103,5 +103,14 @@ namespace Colourful.Conversion
             LChabColor result = ToLChab(xyzColor);
             return result;
         }
+
+        public LChabColor ToLChab<T>(T color) where T : IColorVector
+        {
+            if (color == null) throw new ArgumentNullException("color");
+
+            dynamic source = color;
+
+            return ToLChab(source);
+        }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLChab.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLChab.cs
@@ -108,9 +108,18 @@ namespace Colourful.Conversion
         {
             if (color == null) throw new ArgumentNullException("color");
 
-            dynamic source = color;
+            LChabColor converted = color as LChabColor;
 
-            return ToLChab(source);
+            if (converted != null)
+            {
+                return converted;
+            }
+            else
+            {
+                dynamic source = color;
+
+                return ToLChab(source);
+            }
         }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLChuv.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLChuv.cs
@@ -103,7 +103,9 @@ namespace Colourful.Conversion
             LChuvColor result = ToLChuv(xyzColor);
             return result;
         }
-
+        
+#if (NET35)
+#else
         public LChuvColor ToLChuv<T>(T color) where T : IColorVector
         {
             if (color == null) throw new ArgumentNullException("color");
@@ -121,5 +123,6 @@ namespace Colourful.Conversion
                 return ToLChuv(source);
             }
         }
+#endif
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLChuv.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLChuv.cs
@@ -108,9 +108,18 @@ namespace Colourful.Conversion
         {
             if (color == null) throw new ArgumentNullException("color");
 
-            dynamic source = color;
+            LChuvColor converted = color as LChuvColor;
 
-            return ToLChuv(source);
+            if (converted != null)
+            {
+                return converted;
+            }
+            else
+            {
+                dynamic source = color;
+
+                return ToLChuv(source);
+            }
         }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLChuv.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLChuv.cs
@@ -103,5 +103,14 @@ namespace Colourful.Conversion
             LChuvColor result = ToLChuv(xyzColor);
             return result;
         }
+
+        public LChuvColor ToLChuv<T>(T color) where T : IColorVector
+        {
+            if (color == null) throw new ArgumentNullException("color");
+
+            dynamic source = color;
+
+            return ToLChuv(source);
+        }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLMS.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLMS.cs
@@ -104,9 +104,18 @@ namespace Colourful.Conversion
         {
             if (color == null) throw new ArgumentNullException("color");
 
-            dynamic source = color;
+            LMSColor converted = color as LMSColor;
 
-            return ToLMS(source);
+            if (converted != null)
+            {
+                return converted;
+            }
+            else
+            {
+                dynamic source = color;
+
+                return ToLMS(source);
+            }
         }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLMS.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLMS.cs
@@ -99,7 +99,9 @@ namespace Colourful.Conversion
             LMSColor result = ToLMS(xyzColor);
             return result;
         }
-
+        
+#if (NET35)
+#else
         public LMSColor ToLMS<T>(T color) where T : IColorVector
         {
             if (color == null) throw new ArgumentNullException("color");
@@ -117,5 +119,6 @@ namespace Colourful.Conversion
                 return ToLMS(source);
             }
         }
+#endif
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLMS.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLMS.cs
@@ -99,5 +99,14 @@ namespace Colourful.Conversion
             LMSColor result = ToLMS(xyzColor);
             return result;
         }
+
+        public LMSColor ToLMS<T>(T color) where T : IColorVector
+        {
+            if (color == null) throw new ArgumentNullException("color");
+
+            dynamic source = color;
+
+            return ToLMS(source);
+        }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLab.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLab.cs
@@ -117,9 +117,18 @@ namespace Colourful.Conversion
         {
             if (color == null) throw new ArgumentNullException("color");
 
-            dynamic source = color;
+            LabColor converted = color as LabColor;
 
-            return ToLab(source);
+            if (converted != null)
+            {
+                return converted;
+            }
+            else
+            {
+                dynamic source = color;
+
+                return ToLab(source);
+            }
         }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLab.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLab.cs
@@ -112,5 +112,14 @@ namespace Colourful.Conversion
             LabColor result = ToLab(xyzColor);
             return result;
         }
+
+        public LabColor ToLab<T>(T color) where T : IColorVector
+        {
+            if (color == null) throw new ArgumentNullException("color");
+
+            dynamic source = color;
+
+            return ToLab(source);
+        }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLab.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLab.cs
@@ -112,7 +112,9 @@ namespace Colourful.Conversion
             LabColor result = ToLab(xyzColor);
             return result;
         }
-
+        
+#if (NET35)
+#else
         public LabColor ToLab<T>(T color) where T : IColorVector
         {
             if (color == null) throw new ArgumentNullException("color");
@@ -130,5 +132,6 @@ namespace Colourful.Conversion
                 return ToLab(source);
             }
         }
+#endif
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLinearRGB.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLinearRGB.cs
@@ -108,5 +108,14 @@ namespace Colourful.Conversion
             LinearRGBColor result = ToLinearRGB(xyzColor);
             return result;
         }
+
+        public LinearRGBColor ToLinearRGB<T>(T color) where T : IColorVector
+        {
+            if (color == null) throw new ArgumentNullException("color");
+
+            dynamic source = color;
+
+            return ToLinearRGB(source);
+        }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLinearRGB.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLinearRGB.cs
@@ -108,7 +108,9 @@ namespace Colourful.Conversion
             LinearRGBColor result = ToLinearRGB(xyzColor);
             return result;
         }
-
+        
+#if (NET35)
+#else
         public LinearRGBColor ToLinearRGB<T>(T color) where T : IColorVector
         {
             if (color == null) throw new ArgumentNullException("color");
@@ -126,5 +128,6 @@ namespace Colourful.Conversion
                 return ToLinearRGB(source);
             }
         }
+#endif
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLinearRGB.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLinearRGB.cs
@@ -113,9 +113,18 @@ namespace Colourful.Conversion
         {
             if (color == null) throw new ArgumentNullException("color");
 
-            dynamic source = color;
+            LinearRGBColor converted = color as LinearRGBColor;
 
-            return ToLinearRGB(source);
+            if (converted != null)
+            {
+                return converted;
+            }
+            else
+            {
+                dynamic source = color;
+
+                return ToLinearRGB(source);
+            }
         }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLuv.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLuv.cs
@@ -112,7 +112,9 @@ namespace Colourful.Conversion
             LuvColor result = ToLuv(xyzColor);
             return result;
         }
-
+        
+#if (NET35)
+#else
         public LuvColor ToLuv<T>(T color) where T : IColorVector
         {
             if (color == null) throw new ArgumentNullException("color");
@@ -130,5 +132,6 @@ namespace Colourful.Conversion
                 return ToLuv(source);
             }
         }
+#endif
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLuv.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLuv.cs
@@ -117,9 +117,18 @@ namespace Colourful.Conversion
         {
             if (color == null) throw new ArgumentNullException("color");
 
-            dynamic source = color;
+            LuvColor converted = color as LuvColor;
 
-            return ToLuv(source);
+            if (converted != null)
+            {
+                return converted;
+            }
+            else
+            {
+                dynamic source = color;
+
+                return ToLuv(source);
+            }
         }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToLuv.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToLuv.cs
@@ -112,5 +112,14 @@ namespace Colourful.Conversion
             LuvColor result = ToLuv(xyzColor);
             return result;
         }
+
+        public LuvColor ToLuv<T>(T color) where T : IColorVector
+        {
+            if (color == null) throw new ArgumentNullException("color");
+
+            dynamic source = color;
+
+            return ToLuv(source);
+        }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToRGB.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToRGB.cs
@@ -117,6 +117,8 @@ namespace Colourful.Conversion
             return result;
         }
 
+#if (NET35)
+#else
         public RGBColor ToRGB<T>(T color) where T : IColorVector
         {
             if (color == null) throw new ArgumentNullException("color");
@@ -134,5 +136,6 @@ namespace Colourful.Conversion
                 return ToRGB(source);
             }
         }
+#endif
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToRGB.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToRGB.cs
@@ -116,5 +116,14 @@ namespace Colourful.Conversion
             RGBColor result = ToRGB(xyzColor);
             return result;
         }
+
+        public RGBColor ToRGB<T>(T color) where T : IColorVector
+        {
+            if (color == null) throw new ArgumentNullException("color");
+
+            dynamic source = color;
+
+            return ToRGB(source);
+        }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToRGB.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToRGB.cs
@@ -121,9 +121,18 @@ namespace Colourful.Conversion
         {
             if (color == null) throw new ArgumentNullException("color");
 
-            dynamic source = color;
+            RGBColor converted = color as RGBColor;
 
-            return ToRGB(source);
+            if (converted != null)
+            {
+                return converted;
+            }
+            else
+            {
+                dynamic source = color;
+
+                return ToRGB(source);
+            }
         }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToXYZ.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToXYZ.cs
@@ -156,9 +156,20 @@ namespace Colourful.Conversion
 
         public XYZColor ToXYZ<T>(T color) where T : IColorVector
         {
-            dynamic source = color;
+            if (color == null) throw new ArgumentNullException("color");
 
-            return ToXYZ(source);
+            XYZColor converted = color as XYZColor;
+
+            if (converted != null)
+            {
+                return converted;
+            }
+            else
+            {
+                dynamic source = color;
+
+                return ToXYZ(source);
+            }
         }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToXYZ.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToXYZ.cs
@@ -154,6 +154,8 @@ namespace Colourful.Conversion
             return converted;
         }
 
+#if (NET35)
+#else
         public XYZColor ToXYZ<T>(T color) where T : IColorVector
         {
             if (color == null) throw new ArgumentNullException("color");
@@ -171,5 +173,6 @@ namespace Colourful.Conversion
                 return ToXYZ(source);
             }
         }
+#endif
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToXYZ.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToXYZ.cs
@@ -153,5 +153,12 @@ namespace Colourful.Conversion
             XYZColor converted = converter.Convert(color);
             return converted;
         }
+
+        public XYZColor ToXYZ<T>(T color) where T : IColorVector
+        {
+            dynamic source = color;
+
+            return ToXYZ(source);
+        }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToxyY.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToxyY.cs
@@ -110,5 +110,15 @@ namespace Colourful.Conversion
             xyYColor result = ToxyY(xyzColor);
             return result;
         }
+
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Toxy")]
+        public xyYColor ToxyY<T>(T color) where T : IColorVector
+        {
+            if (color == null) throw new ArgumentNullException("color");
+
+            dynamic source = color;
+
+            return ToxyY(source);
+        }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToxyY.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToxyY.cs
@@ -116,9 +116,18 @@ namespace Colourful.Conversion
         {
             if (color == null) throw new ArgumentNullException("color");
 
-            dynamic source = color;
+            xyYColor converted = color as xyYColor;
 
-            return ToxyY(source);
+            if (converted != null)
+            {
+                return converted;
+            }
+            else
+            {
+                dynamic source = color;
+
+                return ToxyY(source);
+            }
         }
     }
 }

--- a/Colourful/Conversion/ColourfulConverter.ToxyY.cs
+++ b/Colourful/Conversion/ColourfulConverter.ToxyY.cs
@@ -110,7 +110,9 @@ namespace Colourful.Conversion
             xyYColor result = ToxyY(xyzColor);
             return result;
         }
-
+        
+#if (NET35)
+#else
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Toxy")]
         public xyYColor ToxyY<T>(T color) where T : IColorVector
         {
@@ -129,5 +131,6 @@ namespace Colourful.Conversion
                 return ToxyY(source);
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
I added overloads to each ColourfulConverter to allow conversion from an arbitrary IColorVector instance. This uses an old dynamic dispatch trick to invoke the appropriate non-generic method based on the actual class type implementing the interface.

I've only had time to add a single test but it proves the approach works as expected.

I can now pass around instances of IColorVector rather than a specific type and transparently convert to the desired type.