### PR TITLE
Various performance improvements and minor tweaks

### DIFF
--- a/src/Colourful/Conversion/ColourfulConverter.ToLChab.cs
+++ b/src/Colourful/Conversion/ColourfulConverter.ToLChab.cs
@@ -62,7 +62,7 @@ namespace Colourful.Conversion
             // adaptation to target lab white point (LabWhitePoint)
             var adapted = IsChromaticAdaptationPerformed ? Adapt(color) : color;
 
-            // conversion (perserving white point)
+            // conversion (preserving white point)
             var converter = new LabToLChabConverter();
             var result = converter.Convert(adapted);
             return result;

--- a/src/Colourful/Conversion/ColourfulConverter.ToLChuv.cs
+++ b/src/Colourful/Conversion/ColourfulConverter.ToLChuv.cs
@@ -89,7 +89,7 @@ namespace Colourful.Conversion
             // adaptation to target luv white point (LuvWhitePoint)
             var adapted = IsChromaticAdaptationPerformed ? Adapt(color) : color;
 
-            // conversion (perserving white point)
+            // conversion (preserving white point)
             var converter = new LuvToLChuvConverter();
             var result = converter.Convert(adapted);
             return result;

--- a/src/Colourful/Conversion/ColourfulConverter.ToLab.cs
+++ b/src/Colourful/Conversion/ColourfulConverter.ToLab.cs
@@ -65,7 +65,7 @@ namespace Colourful.Conversion
         {
             if (color == null) throw new ArgumentNullException(nameof(color));
 
-            // conversion (perserving white point)
+            // conversion (preserving white point)
             var converter = new LChabToLabConverter();
             var unadapted = converter.Convert(color);
 

--- a/src/Colourful/Conversion/ColourfulConverter.ToLuv.cs
+++ b/src/Colourful/Conversion/ColourfulConverter.ToLuv.cs
@@ -92,7 +92,7 @@ namespace Colourful.Conversion
         {
             if (color == null) throw new ArgumentNullException(nameof(color));
 
-            // conversion (perserving white point)
+            // conversion (preserving white point)
             var converter = new LChuvToLuvConverter();
             var unadapted = converter.Convert(color);
 

--- a/src/Colourful/Conversion/ColourfulConverter.ToXYZ.cs
+++ b/src/Colourful/Conversion/ColourfulConverter.ToXYZ.cs
@@ -47,6 +47,7 @@ namespace Colourful.Conversion
         public XYZColor ToXYZ(LinearRGBColor color)
         {
             if (color == null) throw new ArgumentNullException(nameof(color));
+
             // conversion
             var converterXyz = GetLinearRGBToXYZConverter(color.WorkingSpace);
             var unadapted = converterXyz.Convert(color);

--- a/src/Colourful/Difference/CIE76ColorDifference.cs
+++ b/src/Colourful/Difference/CIE76ColorDifference.cs
@@ -33,7 +33,12 @@ namespace Colourful.Difference
             if (x.WhitePoint != y.WhitePoint)
                 throw new ArgumentException("Colors must have same white point to be compared.");
 
-            var distance = Extensions.EuclideanDistance(x.Vector, y.Vector);
+            // Euclidean distance
+            var distance = Math.Sqrt(
+                (x.L - y.L)*(x.L - y.L) +
+                (x.a - y.a)*(x.a - y.a) +
+                (x.b - y.b)*(x.b - y.b)
+            );
             return distance;
         }
     }

--- a/src/Colourful/Difference/CIE94ColorDifference.cs
+++ b/src/Colourful/Difference/CIE94ColorDifference.cs
@@ -33,16 +33,16 @@ namespace Colourful.Difference
         private readonly double KL;
 
         /// <summary>
-        /// Construct using weighing factors for <see cref="CIE94ColorDifferenceApplication.GraphicArts"/>.
+        /// Construct using weighting factors for <see cref="CIE94ColorDifferenceApplication.GraphicArts"/>.
         /// </summary>
         public CIE94ColorDifference() : this(CIE94ColorDifferenceApplication.GraphicArts)
         {
         }
 
         /// <summary>
-        /// Construct using weighing factors for given application of color difference
+        /// Construct using weighting factors for given application of color difference
         /// </summary>
-        /// <param name="application"></param>
+        /// <param name="application">A <see cref="CIE94ColorDifferenceApplication"/> value specifying the application area. Different weighting factors are used in the computation depending on the application.</param>
         public CIE94ColorDifference(CIE94ColorDifferenceApplication application)
         {
             switch (application)
@@ -92,6 +92,9 @@ namespace Colourful.Difference
         }
     }
 
+    /// <summary>
+    /// Application area for CIE Delta-E 1994
+    /// </summary>
     public enum CIE94ColorDifferenceApplication
     {
         GraphicArts,

--- a/src/Colourful/Difference/CIE94ColorDifference.cs
+++ b/src/Colourful/Difference/CIE94ColorDifference.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using Colourful.Implementation;
 
 namespace Colourful.Difference
 {
@@ -84,9 +85,9 @@ namespace Colourful.Difference
             var SC = 1 + K1*C1;
             var SH = 1 + K2*C1;
             var dE94 = Math.Sqrt(
-                Math.Pow(dL/(KL*SL), 2) +
-                Math.Pow(dC/(KC*SC), 2) +
-                dH_sq/Math.Pow(KH*SH, 2)
+                MathUtils.Pow2(dL/(KL*SL)) +
+                MathUtils.Pow2(dC/(KC*SC)) +
+                dH_sq/MathUtils.Pow2(KH*SH)
             );
             return dE94;
         }

--- a/src/Colourful/Difference/CIEDE2000ColorDifference.cs
+++ b/src/Colourful/Difference/CIEDE2000ColorDifference.cs
@@ -40,153 +40,111 @@ namespace Colourful.Difference
             if (x.WhitePoint != y.WhitePoint)
                 throw new ArgumentException("Colors must have same white point to be compared.");
 
-            var L = new[] { x.L, y.L };
-            var a = new[] { x.a, y.a };
-            var b = new[] { x.b, y.b };
-
             // 1. Calculate C_prime, h_prime
-            var a_prime = Calculate_a_prime(a, b);
-            var C_prime = Calculate_C_prime(a_prime, b);
-            var h_prime = Calculate_h_prime(a_prime, b);
+            double a_prime0, a_prime1;
+            Calculate_a_prime(x.a, y.a, x.b, y.b, out a_prime0, out a_prime1);
+            double C_prime0, C_prime1;
+            Calculate_C_prime(a_prime0, a_prime1, x.b, y.b, out C_prime0, out C_prime1);
+            double h_prime0, h_prime1;
+            Calculate_h_prime(a_prime0, a_prime1, x.b, y.b, out h_prime0, out h_prime1);
 
             // 2. Calculate dL_prime, dC_prime, dH_prime
-            var dL_prime = L[1] - L[0]; // eq. (8)
-            var dC_prime = C_prime[1] - C_prime[0]; // eq. (9)
-            var dh_prime = Calculate_dh_prime(C_prime, h_prime);
-            var dH_prime = 2*Math.Sqrt(C_prime[0]*C_prime[1])*SinDeg(dh_prime/2); // eq. (11)
+            var dL_prime = y.L - x.L; // eq. (8)
+            var dC_prime = C_prime1 - C_prime0; // eq. (9)
+            var dh_prime = Calculate_dh_prime(C_prime0, C_prime1, h_prime0, h_prime1);
+            var dH_prime = 2*Math.Sqrt(C_prime0*C_prime1)*MathUtils.SinDeg(dh_prime/2); // eq. (11)
 
             // 3. Calculate CIEDE2000 Color-Difference dE00
-            var L_prime_mean = (L[0] + L[1])/2; // eq. (12)
-            var C_prime_mean = (C_prime[0] + C_prime[1])/2; // eq. (13)
-            var h_prime_mean = Calculate_h_prime_mean(h_prime, C_prime);
-            var T = 1 - 0.17*CosDeg(h_prime_mean - 30) + 0.24*CosDeg(2*h_prime_mean)
-                    + 0.32*CosDeg(3*h_prime_mean + 6) - 0.20*CosDeg(4*h_prime_mean - 63); // eq. (15)
-            var dTheta = 30*Math.Exp(-Math.Pow(((h_prime_mean - 275)/25), 2)); // eq. (16)
-            var R_C = 2*Math.Sqrt(Math.Pow(C_prime_mean, 7)/(Math.Pow(C_prime_mean, 7) + Math.Pow(25, 7))); // eq. (17)
-            var S_L = 1 + (0.015*Math.Pow(L_prime_mean - 50, 2))/Math.Sqrt(20 + Math.Pow(L_prime_mean - 50, 2)); // eq. (18)
+            var L_prime_mean = (x.L + y.L)/2; // eq. (12)
+            var C_prime_mean = (C_prime0 + C_prime1)/2; // eq. (13)
+            var h_prime_mean = Calculate_h_prime_mean(h_prime0, h_prime1, C_prime0, C_prime1);
+            var T = 1 - 0.17*MathUtils.CosDeg(h_prime_mean - 30) + 0.24*MathUtils.CosDeg(2*h_prime_mean)
+                    + 0.32*MathUtils.CosDeg(3*h_prime_mean + 6) - 0.20*MathUtils.CosDeg(4*h_prime_mean - 63); // eq. (15)
+            var dTheta = 30*Math.Exp(-MathUtils.Pow2(((h_prime_mean - 275)/25))); // eq. (16)
+            var R_C = 2*Math.Sqrt(MathUtils.Pow7(C_prime_mean)/(MathUtils.Pow7(C_prime_mean) + MathUtils.Pow7(25))); // eq. (17)
+            var S_L = 1 + (0.015*MathUtils.Pow2(L_prime_mean - 50))/Math.Sqrt(20 + MathUtils.Pow2(L_prime_mean - 50)); // eq. (18)
             var S_C = 1 + 0.045*C_prime_mean; // eq. (19)
             var S_H = 1 + 0.015*C_prime_mean*T; // eq. (20)
-            var R_T = -SinDeg(2*dTheta)*R_C; // eq. (21)
+            var R_T = -MathUtils.SinDeg(2*dTheta)*R_C; // eq. (21)
 
             var dE00 = Math.Sqrt(
-                Math.Pow(dL_prime/(k_L*S_L), 2) +
-                Math.Pow(dC_prime/(k_C*S_C), 2) +
-                Math.Pow(dH_prime/(k_H*S_H), 2) +
+                MathUtils.Pow2(dL_prime/(k_L*S_L)) +
+                MathUtils.Pow2(dC_prime/(k_C*S_C)) +
+                MathUtils.Pow2(dH_prime/(k_H*S_H)) +
                 R_T*(dC_prime/(k_C*S_C))*(dH_prime/(k_H*S_H))
             ); // eq. (22)
 
             return dE00;
         }
 
-        /// <summary>
-        /// Compute sine of angle in degrees
-        /// </summary>
-        /// <param name="x">Given angle</param>
-        /// <returns></returns>
-        private static double SinDeg(double x)
+        private static void Calculate_a_prime(double a0, double a1, double b0, double b1, out double a_prime0, out double a_prime1)
         {
-            var x_rad = Angle.DegreeToRadian(x);
-            var y = Math.Sin(x_rad);
-            return y;
+            double C_ab0 = Math.Sqrt(a0 * a0 + b0 * b0); // eq. (2)
+            double C_ab1 = Math.Sqrt(a1 * a1 + b1 * b1);
+
+            var C_ab_mean = (C_ab0 + C_ab1)/2; // eq. (3)
+
+            var G = 0.5d*(1 - Math.Sqrt(MathUtils.Pow7(C_ab_mean)/(MathUtils.Pow7(C_ab_mean) + MathUtils.Pow7(25)))); // eq. (4)
+
+            a_prime0 = (1 + G) * a0; // eq. (5)
+            a_prime1 = (1 + G) * a1;
         }
 
-        /// <summary>
-        /// Compute cosine of angle in degrees
-        /// </summary>
-        /// <param name="x">Given angle</param>
-        /// <returns></returns>
-        private static double CosDeg(double x)
+        private static void Calculate_C_prime(double a_prime0, double a_prime1, double b0, double b1, out double C_prime0, out double C_prime1)
         {
-            var x_rad = Angle.DegreeToRadian(x);
-            var y = Math.Cos(x_rad);
-            return y;
-        }
-
-        private static double[] Calculate_a_prime(double[] a, double[] b)
-        {
-            var C_ab = new double[2];
-            for (var i = 0; i < 2; i++)
-            {
-                C_ab[i] = Math.Sqrt(a[i]*a[i] + b[i]*b[i]); // eq. (2)
-            }
-            var C_ab_mean = (C_ab[0] + C_ab[1])/2; // eq. (3)
-
-            var G = 0.5d*(1 - Math.Sqrt(Math.Pow(C_ab_mean, 7)/(Math.Pow(C_ab_mean, 7) + Math.Pow(25, 7)))); // eq. (4)
-
-            var a_prime = new double[2];
-            for (var i = 0; i < 2; i++)
-            {
-                a_prime[i] = (1 + G)*a[i]; // eq. (5)
-            }
-            return a_prime;
-        }
-
-        private static double[] Calculate_C_prime(double[] a_prime, double[] b)
-        {
-            var C_prime = new double[2];
-            for (var i = 0; i < 2; i++)
-            {
-                C_prime[i] = Math.Sqrt(a_prime[i]*a_prime[i] + b[i]*b[i]); // eq. (6)
-            }
-            return C_prime;
+            C_prime0 = Math.Sqrt(a_prime0*a_prime0 + b0*b0); // eq. (6)
+            C_prime1 = Math.Sqrt(a_prime1*a_prime1 + b1*b1);
         }
 
         [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
-        private static double[] Calculate_h_prime(double[] a_prime, double[] b)
+        private static void Calculate_h_prime(double a_prime0, double a_prime1, double b0, double b1, out double h_prime0, out double h_prime1)
         {
             // eq. (7)
-            var h_prime = new double[2];
-            for (var i = 0; i < 2; i++)
-            {
-                if (b[i] == 0d && a_prime[i] == 0d)
-                    h_prime[i] = 0;
+            var hRadians = Math.Atan2(b0, a_prime0);
+            var hDegrees = Angle.NormalizeDegree(Angle.RadianToDegree(hRadians));
+            h_prime0 = hDegrees;
 
-                var hRadians = Math.Atan2(b[i], a_prime[i]);
-                var hDegrees = Angle.RadianToDegree(hRadians);
-                if (hDegrees < 0)
-                    hDegrees += 360;
-
-                h_prime[i] = hDegrees;
-            }
-            return h_prime;
+            hRadians = Math.Atan2(b1, a_prime1);
+            hDegrees = Angle.NormalizeDegree(Angle.RadianToDegree(hRadians));
+            h_prime1 = hDegrees;
         }
 
         [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
-        private static double Calculate_dh_prime(double[] C_prime, double[] h_prime)
+        private static double Calculate_dh_prime(double C_prime0, double C_prime1, double h_prime0, double h_prime1)
         {
             // eq. (10)
-            if (C_prime[0]*C_prime[1] != 0d)
+            if (C_prime0*C_prime1 != 0d)
             {
-                if (Math.Abs(h_prime[1] - h_prime[0]) <= 180)
-                    return h_prime[1] - h_prime[0];
+                if (Math.Abs(h_prime1 - h_prime0) <= 180)
+                    return h_prime1 - h_prime0;
 
-                if ((h_prime[1] - h_prime[0]) > 180)
-                    return (h_prime[1] - h_prime[0]) - 360;
+                if ((h_prime1 - h_prime0) > 180)
+                    return (h_prime1 - h_prime0) - 360;
 
-                if ((h_prime[1] - h_prime[0]) < -180)
-                    return (h_prime[1] - h_prime[0]) + 360;
+                if ((h_prime1 - h_prime0) < -180)
+                    return (h_prime1 - h_prime0) + 360;
             }
             return 0;
         }
 
         [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
-        private static double Calculate_h_prime_mean(double[] h_prime, double[] C_prime)
+        private static double Calculate_h_prime_mean(double h_prime0, double h_prime1, double C_prime0, double C_prime1)
         {
             // eq. (14)
-            if (C_prime[0]*C_prime[1] != 0d)
+            if (C_prime0*C_prime1 != 0d)
             {
-                if (Math.Abs(h_prime[0] - h_prime[1]) <= 180)
-                    return (h_prime[0] + h_prime[1])/2;
+                if (Math.Abs(h_prime0 - h_prime1) <= 180)
+                    return (h_prime0 + h_prime1)/2;
 
-                if (Math.Abs(h_prime[0] - h_prime[1]) > 180 &&
-                    (h_prime[0] + h_prime[1]) < 360)
-                    return (h_prime[0] + h_prime[1] + 360)/2;
+                if (Math.Abs(h_prime0 - h_prime1) > 180 &&
+                    (h_prime0 + h_prime1) < 360)
+                    return (h_prime0 + h_prime1 + 360)/2;
 
-                if (Math.Abs(h_prime[0] - h_prime[1]) > 180 &&
-                    (h_prime[0] + h_prime[1]) >= 360)
-                    return (h_prime[0] + h_prime[1] - 360)/2;
+                if (Math.Abs(h_prime0 - h_prime1) > 180 &&
+                    (h_prime0 + h_prime1) >= 360)
+                    return (h_prime0 + h_prime1 - 360)/2;
             }
-            return (h_prime[0] + h_prime[1]);
+            return (h_prime0 + h_prime1);
         }
     }
 }

--- a/src/Colourful/Difference/CIEDE2000ColorDifference.cs
+++ b/src/Colourful/Difference/CIEDE2000ColorDifference.cs
@@ -23,7 +23,7 @@ namespace Colourful.Difference
     /// </summary>
     public class CIEDE2000ColorDifference : IColorDifference<LabColor>
     {
-        // parametric weighing factors:
+        // parametric weighting factors:
         private const double k_H = 1;
         private const double k_L = 1;
         private const double k_C = 1;

--- a/src/Colourful/Difference/CMCColorDifference.cs
+++ b/src/Colourful/Difference/CMCColorDifference.cs
@@ -117,6 +117,9 @@ namespace Colourful.Difference
         }
     }
 
+    /// <summary>
+    /// Weighting parameters for CMC l:c
+    /// </summary>
     public enum CMCColorDifferenceThreshold
     {
         /// <summary>

--- a/src/Colourful/Difference/CMCColorDifference.cs
+++ b/src/Colourful/Difference/CMCColorDifference.cs
@@ -76,19 +76,14 @@ namespace Colourful.Difference
 
             var dH_pow2 = da*da + db*db - dC*dC;
             var H1_rad = Math.Atan2(b1, a1);
-            var H1 = Angle.RadianToDegree(H1_rad);
+            var H1 = Angle.NormalizeDegree(Angle.RadianToDegree(H1_rad));
 
-            if (H1 < 0)
-                H1 += 360;
-            else if (H1 > 360)
-                H1 -= 360;
-
-            var C1_pow4 = (C1*C1*C1*C1);
+            var C1_pow4 = MathUtils.Pow4(C1);
             var F = Math.Sqrt(C1_pow4/(C1_pow4 + 1900));
 
             var T = H1 >= 164 && H1 <= 345
-                ? 0.56 + Math.Abs(0.2*CosDeg(H1 + 168))
-                : 0.36 + Math.Abs(0.4*CosDeg(H1 + 35));
+                ? 0.56 + Math.Abs(0.2*MathUtils.CosDeg(H1 + 168))
+                : 0.36 + Math.Abs(0.4*MathUtils.CosDeg(H1 + 35));
 
             var SC = (0.0638*C1)/(1 + 0.0131*C1) + 0.638;
             var SL = L1 < 16
@@ -102,18 +97,6 @@ namespace Colourful.Difference
 
             var dE = Math.Sqrt(dE_1*dE_1 + dE_2*dE_2 + dE_3_pow2);
             return dE;
-        }
-
-        /// <summary>
-        /// Compute cosine of angle in degrees
-        /// </summary>
-        /// <param name="x">Given angle</param>
-        /// <returns></returns>
-        private static double CosDeg(double x)
-        {
-            var x_rad = Angle.DegreeToRadian(x);
-            var y = Math.Cos(x_rad);
-            return y;
         }
     }
 

--- a/src/Colourful/Implementation/Conversion/HunterLab/HunterLabToXYZConverter.cs
+++ b/src/Colourful/Implementation/Conversion/HunterLab/HunterLabToXYZConverter.cs
@@ -31,7 +31,7 @@ namespace Colourful.Implementation.Conversion
             var Ka = ComputeKa(input.WhitePoint);
             var Kb = ComputeKb(input.WhitePoint);
 
-            var Y = Math.Pow(L/100d, 2)*Yn;
+            var Y = MathUtils.Pow2(L/100d)*Yn;
             var X = ((a/Ka)*Math.Sqrt(Y/Yn) + Y/Yn)*Xn;
             var Z = ((b/Kb)*Math.Sqrt(Y/Yn) - Y/Yn)*(-Zn);
 

--- a/src/Colourful/Implementation/Conversion/LChab/LabToLChabConverter.cs
+++ b/src/Colourful/Implementation/Conversion/LChab/LabToLChabConverter.cs
@@ -28,12 +28,7 @@ namespace Colourful.Implementation.Conversion
             double L = input.L, a = input.a, b = input.b;
             var C = Math.Sqrt(a*a + b*b);
             var hRadians = Math.Atan2(b, a);
-            var hDegrees = Angle.RadianToDegree(hRadians);
-
-            if (hDegrees > 360)
-                hDegrees -= 360;
-            else if (hDegrees < 0)
-                hDegrees += 360;
+            var hDegrees = Angle.NormalizeDegree(Angle.RadianToDegree(hRadians));
 
             var output = new LChabColor(L, C, hDegrees, input.WhitePoint);
             return output;

--- a/src/Colourful/Implementation/Conversion/LChuv/LuvToLChuvConverter.cs
+++ b/src/Colourful/Implementation/Conversion/LChuv/LuvToLChuvConverter.cs
@@ -28,12 +28,7 @@ namespace Colourful.Implementation.Conversion
             double L = input.L, u = input.u, v = input.v;
             var C = Math.Sqrt(u*u + v*v);
             var hRadians = Math.Atan2(v, u);
-            var hDegrees = Angle.RadianToDegree(hRadians);
-
-            if (hDegrees > 360)
-                hDegrees -= 360;
-            else if (hDegrees < 0)
-                hDegrees += 360;
+            var hDegrees = Angle.NormalizeDegree(Angle.RadianToDegree(hRadians));
 
             var output = new LChuvColor(L, C, hDegrees, input.WhitePoint);
             return output;

--- a/src/Colourful/Implementation/Conversion/Lab/LabToXYZConverter.cs
+++ b/src/Colourful/Implementation/Conversion/Lab/LabToXYZConverter.cs
@@ -31,11 +31,11 @@ namespace Colourful.Implementation.Conversion
             var fx = a/500d + fy;
             var fz = fy - b/200d;
 
-            var fx3 = Math.Pow(fx, 3);
-            var fz3 = Math.Pow(fz, 3);
+            var fx3 = MathUtils.Pow3(fx);
+            var fz3 = MathUtils.Pow3(fz);
 
             var xr = fx3 > CIEConstants.Epsilon ? fx3 : (116*fx - 16)/CIEConstants.Kappa;
-            var yr = L > CIEConstants.Kappa*CIEConstants.Epsilon ? Math.Pow((L + 16)/116d, 3) : L/CIEConstants.Kappa;
+            var yr = L > CIEConstants.Kappa*CIEConstants.Epsilon ? MathUtils.Pow3((L + 16)/116d) : L/CIEConstants.Kappa;
             var zr = fz3 > CIEConstants.Epsilon ? fz3 : (116*fz - 16)/CIEConstants.Kappa;
 
             double Xr = input.WhitePoint.X, Yr = input.WhitePoint.Y, Zr = input.WhitePoint.Z;

--- a/src/Colourful/Implementation/Conversion/Luv/LuvToXYZConverter.cs
+++ b/src/Colourful/Implementation/Conversion/Luv/LuvToXYZConverter.cs
@@ -32,7 +32,7 @@ namespace Colourful.Implementation.Conversion
             var v0 = Compute_v0(input.WhitePoint);
 
             var Y = L > (CIEConstants.Kappa*CIEConstants.Epsilon)
-                ? Math.Pow((L + 16)/116, 3)
+                ? MathUtils.Pow3((L + 16)/116)
                 : (L/CIEConstants.Kappa);
 
             var a = ((52*L)/(u + 13*L*u0) - 1)/3;

--- a/src/Colourful/Implementation/Conversion/RGB/LinearRGBAndXYZConverterBase.cs
+++ b/src/Colourful/Implementation/Conversion/RGB/LinearRGBAndXYZConverterBase.cs
@@ -37,8 +37,6 @@ namespace Colourful.Implementation.Conversion
             double xr = chromaticity.R.x, xg = chromaticity.G.x, xb = chromaticity.B.x,
                 yr = chromaticity.R.y, yg = chromaticity.G.y, yb = chromaticity.B.y;
 
-            double Sr, Sg, Sb;
-
             var Xr = xr/yr;
             const double Yr = 1;
             var Zr = (1 - xr - yr)/yr;
@@ -60,7 +58,10 @@ namespace Colourful.Implementation.Conversion
 
             var W = workingSpace.WhitePoint.Vector;
 
-            (S.MultiplyBy(W)).AssignVariables(out Sr, out Sg, out Sb);
+            var SW = S.MultiplyBy(W);
+            double Sr = SW[0];
+            double Sg = SW[1];
+            double Sb = SW[2];
 
             Matrix M = new Vector[]
             {

--- a/src/Colourful/Implementation/Conversion/RGB/LinearRGBToRGBConverter.cs
+++ b/src/Colourful/Implementation/Conversion/RGB/LinearRGBToRGBConverter.cs
@@ -41,15 +41,13 @@ namespace Colourful.Implementation.Conversion
         private static RGBColor CompandVector(Vector uncompandedVector, IRGBWorkingSpace workingSpace)
         {
             var companding = workingSpace.Companding;
-            Vector compandedVector = uncompandedVector.Select(companding.Companding).ToList();
-            double R, G, B;
-            compandedVector.AssignVariables(out R, out G, out B);
-
-            R = R.CropRange(0, 1);
-            G = G.CropRange(0, 1);
-            B = B.CropRange(0, 1);
-
-            var result = new RGBColor(R, G, B, workingSpace);
+            Vector compandedVector = new[]
+            {
+                companding.Companding(uncompandedVector[0]).CropRange(0, 1),
+                companding.Companding(uncompandedVector[1]).CropRange(0, 1),
+                companding.Companding(uncompandedVector[2]).CropRange(0, 1)
+            };
+            var result = new RGBColor(compandedVector, workingSpace);
             return result;
         }
 

--- a/src/Colourful/Implementation/Conversion/RGB/LinearRGBToXYZConverter.cs
+++ b/src/Colourful/Implementation/Conversion/RGB/LinearRGBToXYZConverter.cs
@@ -52,10 +52,7 @@ namespace Colourful.Implementation.Conversion
 
             var xyz = _conversionMatrix.MultiplyBy(input.Vector);
 
-            double x, y, z;
-            xyz.AssignVariables(out x, out y, out z);
-
-            var converted = new XYZColor(x, y, z);
+            var converted = new XYZColor(xyz);
             return converted;
         }
 

--- a/src/Colourful/Implementation/Conversion/RGB/RGBToLinearRGBConverter.cs
+++ b/src/Colourful/Implementation/Conversion/RGB/RGBToLinearRGBConverter.cs
@@ -41,9 +41,14 @@ namespace Colourful.Implementation.Conversion
         /// </summary>
         private static Vector UncompandVector(RGBColor rgbColor)
         {
-            var inverseCompanding = rgbColor.WorkingSpace.Companding;
+            var companding = rgbColor.WorkingSpace.Companding;
             var compandedVector = rgbColor.Vector;
-            Vector uncompandedVector = compandedVector.Select(x => inverseCompanding.InverseCompanding(x).CropRange(0, 1)).ToList();
+            Vector uncompandedVector = new[]
+            {
+                companding.InverseCompanding(compandedVector[0]).CropRange(0, 1),
+                companding.InverseCompanding(compandedVector[1]).CropRange(0, 1),
+                companding.InverseCompanding(compandedVector[2]).CropRange(0, 1)
+            };
             return uncompandedVector;
         }
 

--- a/src/Colourful/Implementation/Conversion/RGB/XYZToLinearRGBConverter.cs
+++ b/src/Colourful/Implementation/Conversion/RGB/XYZToLinearRGBConverter.cs
@@ -54,7 +54,7 @@ namespace Colourful.Implementation.Conversion
             if (input == null) throw new ArgumentNullException(nameof(input));
 
             var inputVector = input.Vector;
-            Vector uncompandedVector = _conversionMatrix.MultiplyBy(inputVector).Select(x => x.CropRange(0, 1)).ToList();
+            Vector uncompandedVector = _conversionMatrix.MultiplyBy(inputVector).CropRange(0, 1);
             var result = new LinearRGBColor(uncompandedVector, TargetRGBWorkingSpace);
             return result;
         }

--- a/src/Colourful/Implementation/RGB/LCompanding.cs
+++ b/src/Colourful/Implementation/RGB/LCompanding.cs
@@ -32,7 +32,7 @@ namespace Colourful.Implementation.RGB
         public double InverseCompanding(double channel)
         {
             var V = channel;
-            var v = V <= 0.08 ? 100*V/Kappa : Math.Pow((V + 0.16)/1.16, 3);
+            var v = V <= 0.08 ? 100*V/Kappa : MathUtils.Pow3((V + 0.16)/1.16);
             return v;
         }
 

--- a/src/Colourful/Implementation/Utils/Angle.cs
+++ b/src/Colourful/Implementation/Utils/Angle.cs
@@ -34,5 +34,11 @@ namespace Colourful.Implementation
             var rad = TwoPI*(deg/360d);
             return rad;
         }
+
+        public static double NormalizeDegree(double deg)
+        {
+            var d = deg % 360d;
+            return d >= 0 ? d : (d + 360d);
+        }
     }
 }

--- a/src/Colourful/Implementation/Utils/Extensions.cs
+++ b/src/Colourful/Implementation/Utils/Extensions.cs
@@ -48,24 +48,22 @@ namespace Colourful.Implementation
             return value;
         }
 
-        public static void AssignVariables(this Vector vector, out double component1, out double component2, out double component3)
+        public static Vector CropRange(this Vector vector, double min, double max)
         {
-            if (vector.Count != 3)
-                throw new ArgumentOutOfRangeException(nameof(vector), "Vector must have 3 components.");
+            var croppedVector = new double[vector.Count];
 
-            component1 = vector[0];
-            component2 = vector[1];
-            component3 = vector[2];
-        }
+            for (int i = 0; i < vector.Count; i++)
+            {
+                if (vector[i] < min)
+                    croppedVector[i] = min;
+                else if (vector[i] > max)
+                    croppedVector[i] = max;
+                else
+                    croppedVector[i] = vector[i];
+            }
 
-        public static double EuclideanDistance(Vector vector1, Vector vector2)
-        {
-            if (vector1.Count != vector2.Count)
-                throw new ArgumentException("Vectors are of different size.");
-
-            var sum = vector1.Select((t, i) => (t - vector2[i])*(t - vector2[i])).Sum();
-            var root = Math.Sqrt(sum);
-            return root;
+            // ReSharper disable once CoVariantArrayConversion
+            return croppedVector;
         }
 
         /// <summary>
@@ -99,9 +97,16 @@ namespace Colourful.Implementation
 
         public static Vector MultiplyBy(this Matrix matrix, Vector vector)
         {
-            Matrix vectorAsMatrix = vector.Select(x => new[] { x }).Cast<Vector>().ToArray();
-            Matrix resultAsMatrix = matrix.MultiplyBy(vectorAsMatrix);
-            Vector result = resultAsMatrix.SelectMany(x => x).ToArray();
+            if (matrix[0].Count != vector.Count)
+                throw new ArgumentOutOfRangeException(nameof(matrix), "Non-conformable matrices and vectors cannot be multiplied.");
+
+            var result = new double[matrix.Count];
+
+            for (var i = 0; i < matrix.Count; ++i) // each row of matrix
+                for (var k = 0; k < vector.Count; ++k) // each element of vector
+                    result[i] += matrix[i][k]*vector[k];
+
+            // ReSharper disable once CoVariantArrayConversion
             return result;
         }
 

--- a/src/Colourful/Implementation/Utils/MathUtils.cs
+++ b/src/Colourful/Implementation/Utils/MathUtils.cs
@@ -1,0 +1,88 @@
+﻿#region License
+
+// Copyright (C) Tomáš Pažourek, 2016
+// All rights reserved.
+// 
+// Distributed under MIT license as a part of project Colourful.
+// https://github.com/tompazourek/Colourful
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace Colourful.Implementation
+{
+    /// <summary>
+    /// Math helper functions
+    /// </summary>
+    internal static class MathUtils
+    {
+        /// <summary>
+        /// Compute x^2
+        /// </summary>
+        /// <param name="x">Base</param>
+        /// <returns>Result of the exponentiation</returns>
+        public static double Pow2(double x)
+        {
+            return x*x;
+        }
+
+        /// <summary>
+        /// Compute x^3
+        /// </summary>
+        /// <param name="x">Base</param>
+        /// <returns>Result of the exponentiation</returns>
+        public static double Pow3(double x)
+        {
+            return x*x*x;
+        }
+
+        /// <summary>
+        /// Compute x^4
+        /// </summary>
+        /// <param name="x">Base</param>
+        /// <returns>Result of the exponentiation</returns>
+        public static double Pow4(double x)
+        {
+            return (x*x)*(x*x);
+        }
+
+        /// <summary>
+        /// Compute x^7
+        /// </summary>
+        /// <param name="x">Base</param>
+        /// <returns>Result of the exponentiation</returns>
+        public static double Pow7(double x)
+        {
+            return (x*x*x)*(x*x*x)*x;
+        }
+
+        /// <summary>
+        /// Compute sine of angle in degrees
+        /// </summary>
+        /// <param name="x">Given angle</param>
+        /// <returns></returns>
+        public static double SinDeg(double x)
+        {
+            var x_rad = Angle.DegreeToRadian(x);
+            var y = Math.Sin(x_rad);
+            return y;
+        }
+
+        /// <summary>
+        /// Compute cosine of angle in degrees
+        /// </summary>
+        /// <param name="x">Given angle</param>
+        /// <returns></returns>
+        public static double CosDeg(double x)
+        {
+            var x_rad = Angle.DegreeToRadian(x);
+            var y = Math.Cos(x_rad);
+            return y;
+        }
+    }
+}

--- a/src/Colourful/Other/CCTConverter.cs
+++ b/src/Colourful/Other/CCTConverter.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using Colourful.Implementation;
 
 namespace Colourful
 {
@@ -34,21 +35,21 @@ namespace Colourful
             double x_c;
 
             if (temperature <= 4000) // correctly 1667 <= T <= 4000
-                x_c = -0.2661239*(Math.Pow(10, 9)/Math.Pow(temperature, 3)) - 0.2343580*(Math.Pow(10, 6)/Math.Pow(temperature, 2)) + 0.8776956*(Math.Pow(10, 3)/temperature) + 0.179910;
+                x_c = -0.2661239*(1000000000/MathUtils.Pow3(temperature)) - 0.2343580*(1000000/MathUtils.Pow2(temperature)) + 0.8776956*(1000/temperature) + 0.179910;
 
             else // correctly 4000 <= T <= 25000
-                x_c = -3.0258469*(Math.Pow(10, 9)/Math.Pow(temperature, 3)) + 2.1070379*(Math.Pow(10, 6)/Math.Pow(temperature, 2)) + 0.2226347*(Math.Pow(10, 3)/temperature) + 0.240390;
+                x_c = -3.0258469*(1000000000/MathUtils.Pow3(temperature)) + 2.1070379*(1000000/MathUtils.Pow2(temperature)) + 0.2226347*(1000/temperature) + 0.240390;
 
             double y_c;
 
             if (temperature <= 2222) // correctly 1667 <= T <= 2222
-                y_c = -1.1063814*Math.Pow(x_c, 3) - 1.34811020*Math.Pow(x_c, 2) + 2.18555832*x_c - 0.20219683;
+                y_c = -1.1063814*MathUtils.Pow3(x_c) - 1.34811020*MathUtils.Pow2(x_c) + 2.18555832*x_c - 0.20219683;
 
             else if (temperature <= 4000) // correctly 2222 <= T <= 4000
-                y_c = -0.9549476*Math.Pow(x_c, 3) - 1.37418593*Math.Pow(x_c, 2) + 2.09137015*x_c - 0.16748867;
+                y_c = -0.9549476*MathUtils.Pow3(x_c) - 1.37418593*MathUtils.Pow2(x_c) + 2.09137015*x_c - 0.16748867;
 
             else // correctly 4000 <= T <= 25000
-                y_c = +3.0817580*Math.Pow(x_c, 3) - 5.87338670*Math.Pow(x_c, 2) + 3.75112997*x_c - 0.37001483;
+                y_c = +3.0817580*MathUtils.Pow3(x_c) - 5.87338670*MathUtils.Pow2(x_c) + 3.75112997*x_c - 0.37001483;
 
             return new xyChromaticityCoordinates(x_c, y_c);
         }


### PR DESCRIPTION
This pull request addresses several performance bottlenecks (#18) and brings some other minor tweaks like spelling fixes and refactoring.

Biggest gains come from rewriting matrix-vector multiplication and replacing calls of Math.Pow where the exponent is an integer. In the following some micro-benchmarking results for selected conversion and difference methods:

|                   Method |     Elapsed |  Allocated |    Elapsed (new) | Allocated (new) |
|------------------------- |------------:|-----------:|------------:|-----------:|
|                 RGBToLab | 13,266.9 ns |     5528 B | 2,633.49 ns |     1344 B |
|                 LabToRGB | 12,810.7 ns |     5664 B | 2,979.04 ns |     1568 B |
|                 XYZToLab |  9,846.5 ns |     4352 B | 2,149.70 ns |      992 B |
|                 LabToXYZ |  9,429.8 ns |     4344 B | 1,749.33 ns |      984 B |
|                 RGBToXYZ |  2,835.2 ns |     1176 B |   700.28 ns |      352 B |
|                 XYZToRGB |  3,300.2 ns |     1320 B | 1,251.77 ns |      584 B |
|     CIE76ColorDifference |    247.3 ns |      296 B |    11.25 ns |        0 B |
|     CIE94ColorDifference |    260.0 ns |        0 B |    42.65 ns |        0 B |
| CIEDE2000ColorDifference |  1,235.5 ns |      280 B |   611.14 ns |        0 B |
|       CMCColorDifference |    181.9 ns |        0 B |   198.41 ns |        0 B |
